### PR TITLE
Restore PYTHONPATH bootstrap patch.

### DIFF
--- a/debian/rules.em
+++ b/debian/rules.em
@@ -21,6 +21,9 @@ export DEB_CXXFLAGS_MAINT_APPEND=-DNDEBUG
 # Solve shlibdeps errors in REP136 packages that use GNUInstallDirs:
 export DEB_HOST_MULTIARCH := $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
+# Needed to bootstrap since the ros_workspace package does not yet exist.
+export PYTHONPATH=@(InstallationPrefix)/lib/python3.9/site-packages:@(InstallationPrefix)/lib/python3.8/site-packages
+
 %:
 	dh $@@ -v --buildsystem=cmake
 


### PR DESCRIPTION
This patch was previously applied to the debian/rules template for this package to facilitate finding the ROS installation prefix's python libraries without the ros_workspace package since this is it.

The rosdistro migration tools[1] ought to have preserved these patches however I suspect that behavior is not working correctly when the source and destination distribution are the same.

[1]: https://github.com/ros/rosdistro/tree/master/migration-tools