### PR TITLE
Avoid unusable system state during apt install

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,4 +9,5 @@ Standards-Version: 3.9.2
 Package: ros-humble-ros-workspace
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, 
+Conflicts: libsystemd0 (<= 249.11-0ubuntu3), libudev1 (<= 249.11-0ubuntu3)
 Description: Provides the prefix level environment files for ROS 2 packages.


### PR DESCRIPTION
Installing ROS 2 on a system which hasn't get upgraded the installed packages from the versions published at Jammy release to those published in subsequent updates can result in undesirable behavior of the apt resolver.

The dependency solution that apt presents seems to include the removal of critical system packages. If the user doesn't notice the misbehavior, it could result in an unusable system.

This patch is intended to force the upgrade of the affected packages leaving apt no choice but to install additional packages to meet the dependency requirements rather than uninstalling any packages.

**When merging this PR, please ensure that the PR number is not included in the commit message.**

See ros2/ros2#1272 for details on the exact circumstances that lead to the misbehavior.