### PR TITLE
Warn Noble won't receive updating rolling packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ else()
       "prepend-non-duplicate;${LIBRARY_PATH_ENV_VAR};${CMAKE_INSTALL_LIBDIR}")
     set(MULTIARCH_LIBRARY_PATH_HOOK "env-hooks/multiarch_library_paths.sh.in")
   endif()
-  ament_environment_hooks("${LIBRARY_PATH_HOOK}" "${PYTHONPATH_HOOK}" ${MULTIARCH_LIBRARY_PATH_HOOK})
+  ament_environment_hooks("${LIBRARY_PATH_HOOK}" "${PYTHONPATH_HOOK}" ${MULTIARCH_LIBRARY_PATH_HOOK} "env-hooks/echo_rolling_warning.sh.in")
 endif()
 
 # skip using ament_index/resource_index/parent_prefix_path

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,6 @@ else()
       "prepend-non-duplicate;${LIBRARY_PATH_ENV_VAR};${CMAKE_INSTALL_LIBDIR}")
     set(MULTIARCH_LIBRARY_PATH_HOOK "env-hooks/multiarch_library_paths.sh.in")
   endif()
-  set(
-    AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_echo_rolling_warning
-    "source;${CMAKE_INSTALL_PREFIX}/share/ros_workspace/environment/echo_rolling_warning.sh")
   ament_environment_hooks("${LIBRARY_PATH_HOOK}" "${PYTHONPATH_HOOK}" ${MULTIARCH_LIBRARY_PATH_HOOK} "env-hooks/echo_rolling_warning.sh.in")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,9 @@ else()
       "prepend-non-duplicate;${LIBRARY_PATH_ENV_VAR};${CMAKE_INSTALL_LIBDIR}")
     set(MULTIARCH_LIBRARY_PATH_HOOK "env-hooks/multiarch_library_paths.sh.in")
   endif()
+  set(
+    AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_echo_rolling_warning
+    "source;${CMAKE_INSTALL_PREFIX}/share/ros_workspace/environment/echo_rolling_warning.sh")
   ament_environment_hooks("${LIBRARY_PATH_HOOK}" "${PYTHONPATH_HOOK}" ${MULTIARCH_LIBRARY_PATH_HOOK} "env-hooks/echo_rolling_warning.sh.in")
 endif()
 

--- a/env-hooks/echo_rolling_warning.sh.in
+++ b/env-hooks/echo_rolling_warning.sh.in
@@ -1,1 +1,1 @@
-echo "Warning: ROS Rolling has migrated to Ubuntu 26.04. Ubuntu 24.04 will no longer receive updated ROS Rolling packages."
+if [ -z "$ROS_NO_WARN_ROLLING_EOL" ]; then echo "Warning: ROS Rolling has migrated to Ubuntu 26.04. Ubuntu 24.04 will no longer receive updated ROS Rolling system packages."; fi

--- a/env-hooks/echo_rolling_warning.sh.in
+++ b/env-hooks/echo_rolling_warning.sh.in
@@ -1,0 +1,1 @@
+echo "Warning: ROS Rolling has migrated to Ubuntu 26.04. Ubuntu 24.04 will no longer receive updated ROS Rolling packages."

--- a/env-hooks/echo_rolling_warning.sh.in
+++ b/env-hooks/echo_rolling_warning.sh.in
@@ -1,1 +1,1 @@
-if [ -z "$ROS_NO_WARN_ROLLING_EOL" ]; then echo "Warning: ROS Rolling has migrated to Ubuntu 26.04. Ubuntu 24.04 will no longer receive updated ROS Rolling system packages."; fi
+if [ -z "$ROS_NO_WARN_ROLLING_EOL" ]; then echo "Warning: ROS Rolling has migrated to Ubuntu 26.04. Ubuntu 24.04 will no longer receive updated ROS Rolling system packages." >&2; fi


### PR DESCRIPTION
I expected my `source;...` line to get added to ros_workspace's `package.dsv`, but that doesn't happen. Maybe it's all being overwritten by colcon's package.dsv stuff?

Tried testing with:

```
colcon build --build-base build-merge --install-base install-merge --merge-install --packages-up-to ros_workspace
```

and then sourcing `install-merge`, but no message was printed.